### PR TITLE
added the plugin action links #1

### DIFF
--- a/hide-shipping-free-shipping.php
+++ b/hide-shipping-free-shipping.php
@@ -136,3 +136,14 @@ function wchfsm_declare_woocommerce_block_compatibility() {
 	}
 }
 add_action( 'before_woocommerce_init', 'wchfsm_declare_woocommerce_block_compatibility' );
+
+
+// Plugin Action Lins
+function wchfsm_plugin_action_links( $actions ) {
+	$actions[] = '<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' ) ) . '">' . esc_html__( 'Settings', 'wc-hide-shipping-methods' ) . '</a>';
+	$actions[] = '<a href="#" target="_blank">' . esc_html__( 'Documentation', 'wc-hide-shipping-methods' ) . '</a>';
+
+	return $actions;
+}
+
+add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'wchfsm_plugin_action_links' );


### PR DESCRIPTION
Hello @RiaanKnoetze,

I hope you're doing well.

I've implemented the addition of two plugin action links as outlined in issue #1 . 

These links include access to the settings and documentation, with the settings link specifically directing users to the WooCommerce shipping options page. You can find a preview of the changes in the following [[Screenshot](https://prnt.sc/LdbBC2D46--G)]

I'd appreciate it if you could review these changes and consider merging them into the plugin.

Thank you for your time and consideration!

Best regards,
Mainul Sunvi